### PR TITLE
Attempt to configure CA for insecure device during onboarding to cloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,9 @@ jobs:
         id: args
         run: |
           if ${{ github.ref_type == 'tag' }} ; then
-            echo "args=release --rm-dist" >> $GITHUB_OUTPUT
+            echo "args=release --clean" >> $GITHUB_OUTPUT
           else
-            echo "args=release --rm-dist --skip-validate --skip-publish" >> $GITHUB_OUTPUT
+            echo "args=release --clean --skip=validate --skip=publish" >> $GITHUB_OUTPUT
           fi
           
       - name: Run GoReleaser

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ inject-web: $(CLIENT_APPLICATION_BINARY_PATH)
 .PHONY: inject-web
 
 build:
-	UI_FILE=$(UI_FILE) UI_SEPARATOR=$(UI_SEPARATOR) goreleaser build --rm-dist --single-target --skip-validate
+	UI_FILE=$(UI_FILE) UI_SEPARATOR=$(UI_SEPARATOR) goreleaser build --clean --single-target --skip=validate
 .PHONY: build
 
 test: env


### PR DESCRIPTION
For this use-case, it is expected that the insecure device is within the trust network,
and the client application is behind the proxy that authorizes access